### PR TITLE
Add 100ms delay to `pam_authenticate` loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ options:
 
 ${OBJ}: config.h config.mk
 
-config.h:
+config.h: config.def.h
 	@echo creating $@ from config.def.h
 	@cp config.def.h $@
 

--- a/slock-pam.c
+++ b/slock-pam.c
@@ -367,12 +367,15 @@ main(int argc, char **argv)
 		die("slock: pam_start failed: %s\n", pam_strerror(pamh, pamret));
 
 	for (;;) {
+		const struct timespec retry_interval = {0, 100000000};
+
 		pamret = pam_authenticate(pamh, 0);
 		if (pamret == PAM_SUCCESS)
 			break;
 
 		blank(dpy, EMPTY);
 		XBell(dpy, 100);
+		nanosleep(&retry_interval, NULL);
 	}
 
 	pamret = pam_end(pamh, pamret);


### PR DESCRIPTION
On my system my slock pam setting is set to use **only** a u2f key (no password). With Yubico's `pam_u2f.so` the result is a spinloop that pins my CPU whenever the key is not plugged in.